### PR TITLE
Second part of fix for #11 and #10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ out
 *.iws
 *.iml
 .idea
+/classes
 
 # gradle
 build

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    deobfCompile "net.blay09.mods:BetterMinecraftChat_1.10.2:4.1.4"
-    shade "net.blay09.lib:JavaTMI:0.1.29"
-    shade "net.blay09.lib:JavaIRC:0.0.20"
+    deobfCompile "net.blay09.mods:BetterMinecraftChat_1.10.2:4.1.8"
+    shade "net.blay09.lib:JavaTMI:0.1.33"
+    shade "net.blay09.lib:JavaIRC:0.0.23"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 major_version=2
 minecraft_version=1.10.2
 minor_version=1
-mappings_version=snapshot_20160518
-forge_version=12.18.1.2050
+mappings_version=snapshot_20161111
+forge_version=12.18.3.2221
 mod_name=TwitchIntegration
 mod_id=twitchintegration

--- a/src/main/java/net/blay09/mods/bmc/twitchintegration/CommandTwitch.java
+++ b/src/main/java/net/blay09/mods/bmc/twitchintegration/CommandTwitch.java
@@ -2,6 +2,7 @@ package net.blay09.mods.bmc.twitchintegration;
 
 import com.google.common.collect.Lists;
 import net.blay09.javatmi.TMIClient;
+import net.blay09.javatmi.TwitchMessage;
 import net.blay09.mods.bmc.twitchintegration.handler.TwitchChannel;
 import net.blay09.mods.bmc.twitchintegration.handler.TwitchChatHandler;
 import net.minecraft.command.CommandBase;
@@ -45,9 +46,9 @@ public class CommandTwitch extends CommandBase {
 				twitchClient.send(args[0], message);
 				if(message.startsWith("/me ")) {
 					message = message.substring(4);
-					twitchChatHandler.onActionMessage(twitchClient, args[0], twitchChatHandler.getThisUser(twitchClient), message);
+					twitchChatHandler.onChatMessage(twitchClient, args[0], twitchChatHandler.getThisUser(twitchClient), new TwitchMessage(message, -1, true, 0));
 				} else {
-					twitchChatHandler.onChatMessage(twitchClient, args[0], twitchChatHandler.getThisUser(twitchClient), message);
+					twitchChatHandler.onChatMessage(twitchClient, args[0], twitchChatHandler.getThisUser(twitchClient), new TwitchMessage(message, -1, false, 0));
 				}
 			} else {
 				twitchClient.getTwitchCommands().whisper(args[0], message);

--- a/src/main/java/net/blay09/mods/bmc/twitchintegration/TwitchIntegrationConfig.java
+++ b/src/main/java/net/blay09/mods/bmc/twitchintegration/TwitchIntegrationConfig.java
@@ -69,6 +69,7 @@ public class TwitchIntegrationConfig {
 			JsonObject jsonChannel = jsonChannels.get(i).getAsJsonObject();
 			TwitchChannel channel = new TwitchChannel(jsonChannel.get("name").getAsString());
 			channel.setSubscribersOnly(jsonChannel.has("subscribersOnly") && jsonChannel.get("subscribersOnly").getAsBoolean());
+			channel.setId(jsonChannel.has("channelId")? jsonChannel.get("channelId").getAsInt(): -1);
 			channel.setDeletedMessages(TwitchChannel.DeletedMessages.fromName(jsonChannel.get("deletedMessages").getAsString()));
 			channel.setTargetTabName(jsonStringOr(jsonChannel, "targetTab", channel.getName()));
 			channel.setActive(jsonChannel.has("active") && jsonChannel.get("active").getAsBoolean());
@@ -93,6 +94,7 @@ public class TwitchIntegrationConfig {
 			JsonObject jsonChannel = new JsonObject();
 			jsonChannel.addProperty("name", channel.getName());
 			jsonChannel.addProperty("subscribersOnly", channel.isSubscribersOnly());
+			jsonChannel.addProperty("channelId", channel.getId());
 			jsonChannel.addProperty("deletedMessages", channel.getDeletedMessages().name().toLowerCase());
 			jsonChannel.addProperty("targetTab", channel.getTargetTabName());
 			jsonChannel.addProperty("active", channel.isActive());

--- a/src/main/java/net/blay09/mods/bmc/twitchintegration/handler/TwitchBadge.java
+++ b/src/main/java/net/blay09/mods/bmc/twitchintegration/handler/TwitchBadge.java
@@ -44,7 +44,7 @@ public class TwitchBadge {
 	@Nullable
 	public static TwitchBadge getSubscriberBadge(TwitchChannel channel, int subMonths) {
 		TwitchBadge badge = twitchBadges.get(channel.getName() + "_" + subMonths);
-		if(badge == null) {
+		if(badge == null && channel.getId() != -1) {
 			JsonObject object = CachedAPI.loadCachedAPI("https://badges.twitch.tv/v1/badges/channels/" + channel.getId() + "/display", "badges_" + channel.getName());
 			JsonObject badges = object.getAsJsonObject("badge_sets");
 			if(badges.has("subscriber")) {
@@ -56,8 +56,8 @@ public class TwitchBadge {
 				} catch (IOException | URISyntaxException e) {
 					e.printStackTrace();
 				}
+				twitchBadges.put(channel.getName() + "_" + subMonths, badge);
 			}
-			twitchBadges.put(channel.getName() + "_" + subMonths, badge);
 		}
 		return badge;
 	}

--- a/src/main/java/net/blay09/mods/bmc/twitchintegration/handler/TwitchChannel.java
+++ b/src/main/java/net/blay09/mods/bmc/twitchintegration/handler/TwitchChannel.java
@@ -31,17 +31,19 @@ public class TwitchChannel {
 	private boolean subscribersOnly;
 	private DeletedMessages deletedMessages = DeletedMessages.SHOW;
 	private boolean active;
-	private int id;
+	private int id = -1;
 
 	public TwitchChannel(String name) {
 		this.name = name;
 		targetChannelName = name;
-		JsonObject object = CachedAPI.loadCachedAPI("https://api.twitch.tv/kraken/channels/" + name + "?client_id=" + TwitchHelper.OAUTH_CLIENT_ID, "info_" + name);
-		id = object.get("_id").getAsInt();
 	}
 
 	public int getId() {
 		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
 	}
 
 	public String getName() {

--- a/src/main/resources/assets/twitchintegration/lang/en_US.lang
+++ b/src/main/resources/assets/twitchintegration/lang/en_US.lang
@@ -37,5 +37,7 @@ twitchintegration:gui.awaitingResponse.followInstructions=Please switch to your 
 
 twitchintegration:chat.subscribe=%s just subscribed!
 twitchintegration:chat.subscribeMulti=[%s] %s just subscribed!
+twitchintegration:chat.subscribePrime=%s just subscribed with Twitch Prime!
+twitchintegration:chat.subscribePrimeMulti=[%s] %s just subscribed with Twitch Prime!
 twitchintegration:chat.resubscribe=%s has subscribed for %d months in a row!
 twitchintegration:chat.resubscribeMulti=[%s] %s has subscribed for %d months in a row!


### PR DESCRIPTION
The second part of the loyalty badge fix, for #11, for the local player, the info about how many months and bits wasn't saved to the local player, so that was the fix.

Second part of a possible fix for #10 and saving the id of the channel so it won't need to set it each time
If the player hasn't gotten the id from chat and tries to say anything, there won't be a sub badge. Not sure on an implementation to fix that, maybe do the api call here if we haven't gotten the id already and set it for the future? 

Updated to latest JavaTMI and therefore added message for prime sub and added message from resubs and fixed sub message from always being for multi channels
Bumped Forge version