### PR TITLE
Some bug fixes and added a fallback for messages sent to channels with no id

### DIFF
--- a/src/main/java/net/blay09/mods/bmc/twitchintegration/CommandTwitch.java
+++ b/src/main/java/net/blay09/mods/bmc/twitchintegration/CommandTwitch.java
@@ -46,13 +46,13 @@ public class CommandTwitch extends CommandBase {
 				twitchClient.send(args[0], message);
 				if(message.startsWith("/me ")) {
 					message = message.substring(4);
-					twitchChatHandler.onChatMessage(twitchClient, args[0], twitchChatHandler.getThisUser(twitchClient), new TwitchMessage(message, -1, true, 0));
+					twitchChatHandler.onChatMessage(twitchClient, args[0], twitchChatHandler.getThisUser(twitchClient, args[0]), new TwitchMessage(message, -1, true, 0));
 				} else {
-					twitchChatHandler.onChatMessage(twitchClient, args[0], twitchChatHandler.getThisUser(twitchClient), new TwitchMessage(message, -1, false, 0));
+					twitchChatHandler.onChatMessage(twitchClient, args[0], twitchChatHandler.getThisUser(twitchClient, args[0]), new TwitchMessage(message, -1, false, 0));
 				}
 			} else {
 				twitchClient.getTwitchCommands().whisper(args[0], message);
-				twitchChatHandler.onWhisperMessage(twitchClient, twitchChatHandler.getThisUser(twitchClient), twitchChatHandler.getUser(args[0]), message);
+				twitchChatHandler.onWhisperMessage(twitchClient, twitchChatHandler.getThisUser(twitchClient, null), twitchChatHandler.getUser(args[0]), message);
 			}
 		}
 	}

--- a/src/main/java/net/blay09/mods/bmc/twitchintegration/handler/TwitchManager.java
+++ b/src/main/java/net/blay09/mods/bmc/twitchintegration/handler/TwitchManager.java
@@ -59,6 +59,12 @@ public class TwitchManager {
 		}
 
 		for(TwitchChannel channel : channels.values()) {
+			IChatChannel twitchTab = BetterMinecraftChatAPI.getChatChannel(channel.getName(), false);
+			if(channel.getTargetTabName().equals(channel.getName())) {
+				twitchTab.setDisplayChannel(null);
+			} else {
+				twitchTab.setDisplayChannel(BetterMinecraftChatAPI.getChatChannel(channel.getTargetTabName(), false));
+			}
 			channel.setTargetTab(BetterMinecraftChatAPI.getChatChannel(channel.getTargetTabName(), false));
 		}
 
@@ -69,6 +75,7 @@ public class TwitchManager {
 			for(TwitchChannel channel : channels.values()) {
 				if(channel.isActive()) {
 					builder.autoJoinChannel("#" + channel.getName().toLowerCase());
+					activeChannels.add(channel);
 				}
 			}
 			twitchClient = new TMIClient(builder.build(), TwitchIntegration.getTwitchChatHandler());


### PR DESCRIPTION
Fixed so each channel has it's own user to send with as before they overrode each other and the badges wasn't shown in the other channels.

Fixed so the [#name] tags are shown on each message after a startup and having multiple channels as auto join.
Fixed so the channels display their output on the correct tab after startup, all was defaulted to "*" and shown blank on each individual until a deactivate and activate was done.
 
Added a fallback if the player sends a message before receiving one on a new channel to show proper badges, related #10. Tries to get the id from messages first then goes to the fallback if it still isn't set.

Noticed these when working on the other stuff.